### PR TITLE
Bugfix/swagger : swagger 적용시 에러 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-*/resources/application.yml
+src/main/resources/application.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // swagger
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 }
 
 tasks.named('bootBuildImage') {


### PR DESCRIPTION

## 🌟(#1) swagger 적용시 에러 해결


## ✍️내용
implementation 'org.springframework.boot:spring-boot-starter-validation' 디펜던시 추가로 해결
spring boot 3.0 을사용하면서 hibernate validation 버전이 안맞어서 생기는 문제? 인것같다. spring boot-starter-validation이 버전을 잡아줘서 해결되는듯하다

## 📸스크린샷


## 🎈참고사항
org.springframework.boot:spring-boot-starter-validation 디펜던시 추가