### PR TITLE
Bugfix/chat/token : Chat 저장 및 전송 데이터 수정

### DIFF
--- a/src/main/java/com/server/gummymurderer/domain/dto/chat/AIChatRequest.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/chat/AIChatRequest.java
@@ -14,6 +14,8 @@ import java.util.Map;
 @AllArgsConstructor
 public class AIChatRequest {
 
+    private Long gameSetNo;
+    private String secretKey;
     private String sender;
     private String receiver;
     private String chatContent;

--- a/src/main/java/com/server/gummymurderer/domain/dto/chat/ChatSaveRequest.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/chat/ChatSaveRequest.java
@@ -19,6 +19,7 @@ public class ChatSaveRequest {
     private String chatContent;
     private int chatDay;
     private Long gameSetNo;
+    private String secretKey = "";
 
     public static Chat toEntity(ChatSaveRequest request, LocalDateTime time, ChatRoleType senderType, ChatRoleType receiverType, GameSet gameSet) {
         return Chat.builder()

--- a/src/main/java/com/server/gummymurderer/domain/dto/chat/NpcChatAIResponse.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/chat/NpcChatAIResponse.java
@@ -12,6 +12,6 @@ import java.util.List;
 public class NpcChatAIResponse {
 
     private List<NpcChatResponse> chatContent;
-    private int totalTokens;
+    private Tokens tokens;
 
 }

--- a/src/main/java/com/server/gummymurderer/domain/dto/chat/NpcChatRequest.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/chat/NpcChatRequest.java
@@ -12,6 +12,10 @@ public class NpcChatRequest {
     private String sender;
     private String npcName1;
     private String npcName2;
+    private int chatDay;
+    private Long gameSetNo;
+    private String secretKey="";
+
     private String previousStory;
 
 }

--- a/src/main/java/com/server/gummymurderer/domain/dto/chat/NpcChatRequestDto.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/chat/NpcChatRequestDto.java
@@ -11,4 +11,5 @@ public class NpcChatRequestDto {
     private String npcName2;
     private int chatDay;
     private Long gameSetNo;
+    private String secretKey="";
 }

--- a/src/main/java/com/server/gummymurderer/domain/dto/chat/Tokens.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/chat/Tokens.java
@@ -1,5 +1,6 @@
 package com.server.gummymurderer.domain.dto.chat;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,12 +10,9 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class AIChatResponse {
-
-    private String sender;       // 수신자 이름
-    private String receiver;     // 발신자 이름
-    private String chatContent;  // 채팅 내용
-    private Tokens tokens;
-
+public class Tokens {
+    private long totalTokens;
+    private long promptTokens;
+    private long completionTokens;
+    private String totalCost;
 }
-

--- a/src/main/java/com/server/gummymurderer/domain/dto/gameNpc/GameNpcDTO.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/gameNpc/GameNpcDTO.java
@@ -20,7 +20,6 @@ public class GameNpcDTO {
     private float npcDeathLocationY;
     private float npcDeathLocationZ;
     private long npcDeathNightNumber;
-    private long npcToken;
 
 
     public  GameNpcDTO(GameNpc gameNpc) {
@@ -34,7 +33,6 @@ public class GameNpcDTO {
         this.npcDeathLocationY = gameNpc.getNpcDeathLocationY();
         this.npcDeathLocationZ = gameNpc.getNpcDeathLocationZ();
         this.npcDeathNightNumber = gameNpc.getNpcDeathNightNumber();
-        this.npcToken = gameNpc.getNpcToken();
     }
 
 

--- a/src/main/java/com/server/gummymurderer/domain/entity/GameNpc.java
+++ b/src/main/java/com/server/gummymurderer/domain/entity/GameNpc.java
@@ -43,8 +43,11 @@ public class GameNpc extends BaseEntity {
     @Column(name = "npc_death_night_number")
     private long npcDeathNightNumber;
 
-    @Column(name = "npc_token")
-    private long npcToken;
+    @Column(name = "prompt_tokens")
+    private long gameNpcPromptTokens;
+
+    @Column(name = "completion_tokens")
+    private long gameNpcCompletionTokens;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_set_no")
@@ -61,11 +64,16 @@ public class GameNpc extends BaseEntity {
         this.npcDeathLocationY = 0;
         this.npcDeathLocationZ = 0;
         this.npcDeathNightNumber = 0;
-        this.npcToken = 0;
         this.gameSet = gameSet;
     }
 
     public void voteEvent() {
         this.npcStatus = "dead";
     }
+
+    public void updateTokens(long promptTokens, long completionTokens) {
+        this.gameNpcPromptTokens += promptTokens;
+        this.gameNpcCompletionTokens += completionTokens;
+    }
+
 }

--- a/src/main/java/com/server/gummymurderer/repository/GameNpcRepository.java
+++ b/src/main/java/com/server/gummymurderer/repository/GameNpcRepository.java
@@ -23,5 +23,9 @@ public interface GameNpcRepository extends JpaRepository<GameNpc, Long> {
     @Query(value = "SELECT npc_name FROM gummymurderer.game_npc_tb WHERE game_set_no = :gameSetNo AND npc_job = 'Murderer'", nativeQuery = true)
     String findMurderByGameSetNo(@Param("gameSetNo") Long gameSetNo);
 
-    Optional<GameNpc> findByGameNpcNoAndGameSet(Long gameNpcNo, GameSet gameSet);
+    Optional<GameNpc> findByNpcNameAndGameSet(String npcName, GameSet gameSet);
+
+    Optional<GameNpc> findByNpcNameAndGameSet_GameSetNo(String npcName, Long gameSetNo);
+
+    List<GameNpc> findAllByNpcNameInAndGameSet_GameSetNo(List<String> npcNames, Long gameSetNo);
 }

--- a/src/main/java/com/server/gummymurderer/repository/GameNpcRepository.java
+++ b/src/main/java/com/server/gummymurderer/repository/GameNpcRepository.java
@@ -28,4 +28,6 @@ public interface GameNpcRepository extends JpaRepository<GameNpc, Long> {
     Optional<GameNpc> findByNpcNameAndGameSet_GameSetNo(String npcName, Long gameSetNo);
 
     List<GameNpc> findAllByNpcNameInAndGameSet_GameSetNo(List<String> npcNames, Long gameSetNo);
+
+    Optional<GameNpc> findByGameNpcNoAndGameSet(Long gameNpcNo, GameSet gameSet);
 }

--- a/src/main/java/com/server/gummymurderer/service/ChatService.java
+++ b/src/main/java/com/server/gummymurderer/service/ChatService.java
@@ -2,12 +2,14 @@ package com.server.gummymurderer.service;
 
 import com.server.gummymurderer.domain.dto.chat.*;
 import com.server.gummymurderer.domain.entity.Chat;
+import com.server.gummymurderer.domain.entity.GameNpc;
 import com.server.gummymurderer.domain.entity.GameScenario;
 import com.server.gummymurderer.domain.entity.GameSet;
 import com.server.gummymurderer.domain.enum_class.ChatRoleType;
 import com.server.gummymurderer.exception.AppException;
 import com.server.gummymurderer.exception.ErrorCode;
 import com.server.gummymurderer.repository.ChatRepository;
+import com.server.gummymurderer.repository.GameNpcRepository;
 import com.server.gummymurderer.repository.GameScenarioRepository;
 import com.server.gummymurderer.repository.GameSetRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ public class ChatService {
 
     private final ChatRepository chatRepository;
     private final GameSetRepository gameSetRepository;
+    private final GameNpcRepository gameNpcRepository;
     private final GameScenarioRepository gameScenarioRepository;
 
     // 채팅 보내기
@@ -63,7 +66,7 @@ public class ChatService {
 
         // 이전 스토리 내용 가져오기
         Optional<GameScenario> gameScenarioOptional = gameScenarioRepository.findByGameSet_GameSetNo(request.getGameSetNo());
-        String previousStory = gameScenarioOptional.map(GameScenario::getDailySummary).orElse(null);
+        String previousStory = gameScenarioOptional.map(GameScenario::getDailySummary).orElse("");
 
         // AI 서버에 보낼 요청 객체 생성
         AIChatRequest aiChatRequest = new AIChatRequest();
@@ -72,6 +75,8 @@ public class ChatService {
         aiChatRequest.setChatContent(request.getChatContent());
         aiChatRequest.setChatDay(request.getChatDay());
         aiChatRequest.setPreviousStory(previousStory);
+        aiChatRequest.setSecretKey(request.getSecretKey());
+        aiChatRequest.setGameSetNo(request.getGameSetNo());
 
         // 이전 채팅 내용에서 필요한 정보만 추출
         List<Map<String, Object>> simplifiedPreviousChats = previousChatContents.stream()
@@ -112,6 +117,12 @@ public class ChatService {
                     aiChat.setChatContent(aiResponse.getChatContent());
                     aiChat.setChatDay(request.getChatDay());
 
+                    // tokens 업데이트
+                    GameNpc gameNpc = gameNpcRepository.findByNpcNameAndGameSet_GameSetNo(request.getReceiver(), request.getGameSetNo())
+                            .orElseThrow(() -> new AppException(ErrorCode.NPC_NOT_FOUND));
+
+                    gameNpc.updateTokens(aiResponse.getTokens().getPromptTokens(), aiResponse.getTokens().getCompletionTokens());
+
                     Optional<GameSet> optionalGameSet = gameSetRepository.findByGameSetNo(request.getGameSetNo());
 
                     if (optionalGameSet.isEmpty()) {
@@ -136,29 +147,42 @@ public class ChatService {
 
     // npc 채팅 요청 및 반환
     public Mono<List<NpcChatResponse>> getNpcChat(NpcChatRequestDto npcChatRequestDto) {
-        return sendNpcChatToAIServer(npcChatRequestDto.getSender(), npcChatRequestDto.getNpcName1(), npcChatRequestDto.getNpcName2(), npcChatRequestDto.getGameSetNo())
+        return sendNpcChatToAIServer(npcChatRequestDto)
                 .doOnNext(npcChatAIResponse -> {
                     npcChatAIResponse.getChatContent().forEach(response -> {
                         Chat chat = NpcChatResponse.toEntity(response, npcChatRequestDto.getChatDay(), LocalDateTime.now(), ChatRoleType.AI, ChatRoleType.AI);
                         Mono.fromCallable(() -> chatRepository.save(chat)).subscribe();
                     });
-                    gameSetRepository.findByGameSetNo(npcChatRequestDto.getGameSetNo())
-                            .ifPresent(gameSet -> gameSet.updateGameToken(npcChatAIResponse.getTotalTokens()));
+                    // tokens 업데이트
+                    List<String> npcNames = Arrays.asList(npcChatRequestDto.getNpcName1(), npcChatRequestDto.getNpcName2());
+
+                    long promptTokensPerNpc = Math.round((float)npcChatAIResponse.getTokens().getPromptTokens() / 2);
+                    long completionTokensPerNpc = Math.round((float)npcChatAIResponse.getTokens().getCompletionTokens() / 2);
+
+                    List<GameNpc> gameNpcs = gameNpcRepository.findAllByNpcNameInAndGameSet_GameSetNo(npcNames, npcChatRequestDto.getGameSetNo());
+
+                    for (GameNpc gameNpc : gameNpcs) {
+                        gameNpc.updateTokens(promptTokensPerNpc, completionTokensPerNpc);
+                    }
+
                 })
                 .map(NpcChatAIResponse::getChatContent);  // NpcChatAIResponse 객체의 chatContent 필드를 반환
     }
 
-    private Mono<NpcChatAIResponse> sendNpcChatToAIServer(String sender, String npcName1, String npcName2, Long gameSetNo) {
+    private Mono<NpcChatAIResponse> sendNpcChatToAIServer(NpcChatRequestDto npcChatRequestDto) {
         String aiServerUrl = "http://221.163.19.218:9090/api/chatbot/conversation_between_npcs";
         WebClient webClient = WebClient.builder().baseUrl(aiServerUrl).build();
 
-        NpcChatRequest npcChatRequest = new NpcChatRequest();
-        npcChatRequest.setSender(sender);
-        npcChatRequest.setNpcName1(npcName1);
-        npcChatRequest.setNpcName2(npcName2);
-
-        gameScenarioRepository.findByGameSet_GameSetNo(gameSetNo)
-                .ifPresent(gameScenario -> npcChatRequest.setPreviousStory(gameScenario.getDailySummary()));
+        NpcChatRequest npcChatRequest = NpcChatRequest.builder()
+                .gameSetNo(npcChatRequestDto.getGameSetNo())
+                .secretKey(npcChatRequestDto.getSecretKey())
+                .sender(npcChatRequestDto.getSender())
+                .npcName1(npcChatRequestDto.getNpcName1())
+                .npcName2(npcChatRequestDto.getNpcName2())
+                .chatDay(npcChatRequestDto.getChatDay())
+                .previousStory(gameScenarioRepository.findByGameSet_GameSetNo(npcChatRequestDto.getGameSetNo())
+                        .map(GameScenario::getDailySummary).orElse(""))
+                .build();
 
         return webClient.post()
                 .uri(aiServerUrl)


### PR DESCRIPTION
## 🌟(#80 ) Chat 저장 및 전송 데이터 수정


## ✍️내용
- gameNo, secretKey 추가 전송(user-npc, npc-npc)
- promptTokens, completionTokens 저장 (user-npc, npc-npc)
- previousStory가 없을 경우 빈 값으로 전송

## 📸스크린샷


## 🎈참고사항
