### PR TITLE
Bugfix/scenario/npcStatus : npc status 변경

### DIFF
--- a/src/main/java/com/server/gummymurderer/domain/dto/gameNpc/GameNpcDTO.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/gameNpc/GameNpcDTO.java
@@ -1,6 +1,7 @@
 package com.server.gummymurderer.domain.dto.gameNpc;
 
 import com.server.gummymurderer.domain.entity.GameNpc;
+import com.server.gummymurderer.domain.enum_class.NpcStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,14 +17,14 @@ public class GameNpcDTO {
     private String npcJob;
     private String npcPersonality;
     private String npcFeature;
-    private String npcStatus;
+    private NpcStatus npcStatus;
     private Float npcDeathLocationX;
     private Float npcDeathLocationY;
     private Float npcDeathLocationZ;
     private long npcDeathNightNumber;
 
 
-    public  GameNpcDTO(GameNpc gameNpc) {
+    public GameNpcDTO(GameNpc gameNpc) {
         this.gameNpcNo = gameNpc.getGameNpcNo();
         this.npcName = gameNpc.getNpcName();
         this.npcJob = gameNpc.getNpcJob();
@@ -35,5 +36,10 @@ public class GameNpcDTO {
         this.npcDeathLocationZ = gameNpc.getNpcDeathLocationZ();
         this.npcDeathNightNumber = gameNpc.getNpcDeathNightNumber();
     }
+
+    public String getNpcStatus() {
+        return this.npcStatus.name();
+    }
+
 
 }

--- a/src/main/java/com/server/gummymurderer/domain/entity/GameNpc.java
+++ b/src/main/java/com/server/gummymurderer/domain/entity/GameNpc.java
@@ -1,5 +1,6 @@
 package com.server.gummymurderer.domain.entity;
 
+import com.server.gummymurderer.domain.enum_class.NpcStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -28,8 +29,9 @@ public class GameNpc extends BaseEntity {
     @Column(name = "npc_feature")
     private String npcFeature;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "npc_status")
-    private String npcStatus;
+    private NpcStatus npcStatus;
 
     @Column(name = "npc_death_location_x")
     private float npcDeathLocationX;
@@ -59,7 +61,7 @@ public class GameNpc extends BaseEntity {
         this.npcJob = npcJob;
         this.npcPersonality = npc.getNpcPersonality();
         this.npcFeature = npc.getNpcFeature();
-        this.npcStatus = "alive";
+        this.npcStatus = NpcStatus.ALIVE;
         this.npcDeathLocationX = 0;
         this.npcDeathLocationY = 0;
         this.npcDeathLocationZ = 0;
@@ -68,7 +70,11 @@ public class GameNpc extends BaseEntity {
     }
 
     public void voteEvent() {
-        this.npcStatus = "dead";
+        this.npcStatus = NpcStatus.DEAD;
+    }
+
+    public void dead() {
+        this.npcStatus = NpcStatus.DEAD;
     }
 
     public void updateTokens(long promptTokens, long completionTokens) {

--- a/src/main/java/com/server/gummymurderer/domain/enum_class/NpcStatus.java
+++ b/src/main/java/com/server/gummymurderer/domain/enum_class/NpcStatus.java
@@ -1,0 +1,6 @@
+package com.server.gummymurderer.domain.enum_class;
+
+public enum NpcStatus {
+
+    ALIVE, DEAD
+}

--- a/src/main/java/com/server/gummymurderer/repository/GameNpcRepository.java
+++ b/src/main/java/com/server/gummymurderer/repository/GameNpcRepository.java
@@ -18,7 +18,7 @@ public interface GameNpcRepository extends JpaRepository<GameNpc, Long> {
 
     List<GameNpc> findAllByGameSet(GameSet gameSet);
 
-    @Query("SELECT new com.server.gummymurderer.domain.dto.scenario.NpcInfo(n.npcName, n.gameNpcNo) FROM GameNpc n WHERE n.gameSet.gameSetNo = :gameSetNo AND n.npcJob = 'Resident' AND n.npcStatus = 'alive'")
+    @Query("SELECT new com.server.gummymurderer.domain.dto.scenario.NpcInfo(n.npcName, n.gameNpcNo) FROM GameNpc n WHERE n.gameSet.gameSetNo = :gameSetNo AND n.npcJob = 'Resident' AND (n.npcStatus = 'alive' OR n.npcStatus = 'ALIVE')")
     List<NpcInfo> findAllAliveResidentNpcInfoByGameSetNo(@Param("gameSetNo") Long gameSetNo);
 
     @Query(value = "SELECT npc_name FROM gummymurderer.game_npc_tb WHERE game_set_no = :gameSetNo AND npc_job = 'Murderer'", nativeQuery = true)

--- a/src/main/java/com/server/gummymurderer/service/ScenarioService.java
+++ b/src/main/java/com/server/gummymurderer/service/ScenarioService.java
@@ -86,6 +86,13 @@ public class ScenarioService {
 
         GameScenario savedGameScenario = gameScenarioRepository.save(new GameScenario(result, foundGameSet));
 
+        // 피해자 NpcStatus Dead로 변경
+        String victim = result.getAnswer().getVictim();
+        GameNpc victimNpc = gameNpcRepository.findByNpcName(victim)
+                .orElseThrow(() -> new AppException(ErrorCode.NPC_NOT_FOUND));
+        victimNpc.dead();
+        gameNpcRepository.save(victimNpc);
+
         // Alibi 정보를 GameAlibi에 저장
         for (AlibiDTO alibiDTO : result.getAnswer().getAlibis()) {
 


### PR DESCRIPTION
## 🌟(#127 ) npc status 변경


## ✍️내용
- npcStatus enum으로 관리
- scenario에서 살해된 npc의 Status -> 사망으로 변경

## 📸스크린샷


## 🎈참고사항
