### PR TITLE
Bugfix/game/entity : 게임 종료에 대한 상태 값 추가

### DIFF
--- a/src/main/java/com/server/gummymurderer/domain/dto/game/LoginGameSetDTO.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/game/LoginGameSetDTO.java
@@ -15,11 +15,13 @@ public class LoginGameSetDTO {
     private LocalDateTime modifiedAt;
     private int gameDay;
     private String gameStatus;
+    private String gameResult;
 
     public LoginGameSetDTO(GameSet gameSet) {
         this.gameSetNo = gameSet.getGameSetNo();
         this.gameDay = gameSet.getGameDay();
         this.gameStatus = gameSet.getGameStatus().name();
+        this.gameResult = gameSet.getGameResult().name();
         this.createdAt = gameSet.getCreatedAt();
         this.modifiedAt = gameSet.getLastModifiedAt();
     }

--- a/src/main/java/com/server/gummymurderer/domain/entity/GameSet.java
+++ b/src/main/java/com/server/gummymurderer/domain/entity/GameSet.java
@@ -1,5 +1,6 @@
 package com.server.gummymurderer.domain.entity;
 
+import com.server.gummymurderer.domain.enum_class.GameResult;
 import com.server.gummymurderer.domain.enum_class.GameStatus;
 import jakarta.persistence.*;
 import lombok.*;
@@ -22,6 +23,10 @@ public class GameSet extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "game_status")
     private GameStatus gameStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "game_result")
+    private GameResult gameResult;
 
     @Column(name = "game_day")
     private int gameDay;

--- a/src/main/java/com/server/gummymurderer/domain/enum_class/GameResult.java
+++ b/src/main/java/com/server/gummymurderer/domain/enum_class/GameResult.java
@@ -1,0 +1,7 @@
+package com.server.gummymurderer.domain.enum_class;
+
+public enum GameResult {
+
+    IN_PROGRESS, SUCCESS, FAILURE
+
+}

--- a/src/main/java/com/server/gummymurderer/service/GameService.java
+++ b/src/main/java/com/server/gummymurderer/service/GameService.java
@@ -3,6 +3,7 @@ package com.server.gummymurderer.service;
 import com.server.gummymurderer.domain.dto.game.*;
 import com.server.gummymurderer.domain.dto.gameNpc.GameNpcDTO;
 import com.server.gummymurderer.domain.entity.*;
+import com.server.gummymurderer.domain.enum_class.GameResult;
 import com.server.gummymurderer.domain.enum_class.GameStatus;
 import com.server.gummymurderer.exception.AppException;
 import com.server.gummymurderer.exception.ErrorCode;
@@ -42,6 +43,7 @@ public class GameService {
         // Game Set 구성
         GameSet gameSet = GameSet.builder()
                 .gameStatus(GameStatus.GAME_START)
+                .gameResult(GameResult.IN_PROGRESS)
                 .gameDay(1)
                 .gameSummary("")
                 .gameToken(0)


### PR DESCRIPTION
## 🌟(#133 ) 제목


## ✍️내용
- 게임 종료 시 상태 관리 GameResult enum 추가
- 게임이 진행 중일 때와 종료되었을 때 SUCCESS, FAILURE 로 관리

## 📸스크린샷


## 🎈참고사항
