### PR TITLE
Bugfix/entity/game npc : GameNpc deathLocation 추가 및 좌표 값 삭제

### DIFF
--- a/src/main/java/com/server/gummymurderer/domain/dto/gameNpc/GameNpcDTO.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/gameNpc/GameNpcDTO.java
@@ -18,9 +18,7 @@ public class GameNpcDTO {
     private String npcPersonality;
     private String npcFeature;
     private NpcStatus npcStatus;
-    private Float npcDeathLocationX;
-    private Float npcDeathLocationY;
-    private Float npcDeathLocationZ;
+    private String deathLocation;
     private long npcDeathNightNumber;
 
 
@@ -31,9 +29,7 @@ public class GameNpcDTO {
         this.npcPersonality = gameNpc.getNpcPersonality();
         this.npcFeature = gameNpc.getNpcFeature();
         this.npcStatus = gameNpc.getNpcStatus();
-        this.npcDeathLocationX = gameNpc.getNpcDeathLocationX();
-        this.npcDeathLocationY = gameNpc.getNpcDeathLocationY();
-        this.npcDeathLocationZ = gameNpc.getNpcDeathLocationZ();
+        this.deathLocation = gameNpc.getDeathLocation();
         this.npcDeathNightNumber = gameNpc.getNpcDeathNightNumber();
     }
 

--- a/src/main/java/com/server/gummymurderer/domain/entity/GameNpc.java
+++ b/src/main/java/com/server/gummymurderer/domain/entity/GameNpc.java
@@ -33,14 +33,8 @@ public class GameNpc extends BaseEntity {
     @Column(name = "npc_status")
     private NpcStatus npcStatus;
 
-    @Column(name = "npc_death_location_x")
-    private float npcDeathLocationX;
-
-    @Column(name = "npc_death_location_y")
-    private float npcDeathLocationY;
-
-    @Column(name = "npc_death_location_z")
-    private float npcDeathLocationZ;
+    @Column(name = "death_location")
+    private String deathLocation;
 
     @Column(name = "npc_death_night_number")
     private long npcDeathNightNumber;
@@ -62,9 +56,6 @@ public class GameNpc extends BaseEntity {
         this.npcPersonality = npc.getNpcPersonality();
         this.npcFeature = npc.getNpcFeature();
         this.npcStatus = NpcStatus.ALIVE;
-        this.npcDeathLocationX = 0;
-        this.npcDeathLocationY = 0;
-        this.npcDeathLocationZ = 0;
         this.npcDeathNightNumber = 0;
         this.gameSet = gameSet;
     }
@@ -73,8 +64,9 @@ public class GameNpc extends BaseEntity {
         this.npcStatus = NpcStatus.DEAD;
     }
 
-    public void dead() {
+    public void markDeath(String deathLocation) {
         this.npcStatus = NpcStatus.DEAD;
+        this.deathLocation = deathLocation;
     }
 
     public void updateTokens(long promptTokens, long completionTokens) {

--- a/src/main/java/com/server/gummymurderer/service/ChatService.java
+++ b/src/main/java/com/server/gummymurderer/service/ChatService.java
@@ -207,6 +207,7 @@ public class ChatService {
 
                     // tokens 업데이트
                     gameNpc.updateTokens(aiResponse.getTokens().getPromptTokens(), aiResponse.getTokens().getCompletionTokens());
+                    gameNpcRepository.save(gameNpc);
 
                     Optional<GameSet> optionalGameSet = gameSetRepository.findByGameSetNo(request.getGameSetNo());
 
@@ -328,6 +329,7 @@ public class ChatService {
                             .orElseThrow(() -> new AppException(ErrorCode.NPC_NOT_FOUND));
 
                     senderNpc.updateTokens(npcChatResponse.getTokens().getPromptTokens(), npcChatResponse.getTokens().getCompletionTokens());
+                    gameNpcRepository.save(senderNpc);
 
                     Optional<GameSet> optionalGameSet = gameSetRepository.findByGameSetNo(npcChatRequest.getGameSetNo());
 

--- a/src/main/java/com/server/gummymurderer/service/ScenarioService.java
+++ b/src/main/java/com/server/gummymurderer/service/ScenarioService.java
@@ -94,7 +94,8 @@ public class ScenarioService {
         GameNpc victimNpc = gameNpcRepository.findByNpcNameAndGameSet(victim, foundGameSet)
                 .orElseThrow(() -> new AppException(ErrorCode.NPC_NOT_FOUND));
         log.info("🐻 피해자 npc : {}", victimNpc);
-        victimNpc.dead();
+
+        victimNpc.markDeath(savedGameScenario.getCrimeScene());
         gameNpcRepository.save(victimNpc);
 
         // Alibi 정보를 GameAlibi에 저장


### PR DESCRIPTION
## 🌟(#148 ) GameNpc entity 수정


## ✍️내용
-  npcDeathLocation X, Y, Z 좌표 값 저장 컬럼 전체 삭제
- DeathLocation(죽은 장소) 저장 컬럼 추가
- chat token 값 gameNpc entity에 저장 

## 📸스크린샷


## 🎈참고사항
