### PR TITLE
Bugfix/scenario/finalWordGameResult : GameResult가 SUCCESS인 경우에만 finalWords 요청

### DIFF
--- a/src/main/java/com/server/gummymurderer/exception/ErrorCode.java
+++ b/src/main/java/com/server/gummymurderer/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시나리오를 찾을 수 없습니다."),
     ALIBI_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 npc의 alibi를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    GAME_NOT_WON(HttpStatus.BAD_REQUEST, "GameResult가 SUCCESS가 아닙니다."),
 
     ;
 

--- a/src/main/java/com/server/gummymurderer/service/ScenarioService.java
+++ b/src/main/java/com/server/gummymurderer/service/ScenarioService.java
@@ -6,6 +6,7 @@ import com.server.gummymurderer.domain.dto.alibi.AlibiDTO;
 import com.server.gummymurderer.domain.dto.gameNpc.GameNpcDTO;
 import com.server.gummymurderer.domain.dto.scenario.*;
 import com.server.gummymurderer.domain.entity.*;
+import com.server.gummymurderer.domain.enum_class.GameResult;
 import com.server.gummymurderer.exception.AppException;
 import com.server.gummymurderer.exception.ErrorCode;
 import com.server.gummymurderer.repository.GameAlibiRepository;
@@ -176,11 +177,13 @@ public class ScenarioService {
                 .orElseThrow(() -> new AppException(ErrorCode.GAME_SET_NOT_FOUND));
 
         // gameResult 정보 가져오기
-        String gameResult = switch (foundGameSet.getGameResult()) {
-            case SUCCESS -> "victory";
-            case FAILURE -> "defeat";
-            default -> "in_progress";
-        };
+        String gameResult = null;
+
+        if (foundGameSet.getGameResult() == GameResult.SUCCESS) {
+            gameResult = "victory";
+        } else {
+            throw new AppException(ErrorCode.GAME_NOT_WON);
+        }
 
         log.info("🐻 gameResult : {}", foundGameSet.getGameResult());
 


### PR DESCRIPTION
## 🌟(#169 ) finalWord gameResult가 success 일 경우에만 넘어가게 수정


## ✍️내용
- GameResult가 SUCCESS 이외의 값일 경우 예외 처리

## 📸스크린샷


## 🎈참고사항
