### PR TITLE
Bugfix/game/gameEnd : GameEnd 시 GameResult는 FAILURE로만 처리

### DIFF
--- a/src/main/java/com/server/gummymurderer/exception/ErrorCode.java
+++ b/src/main/java/com/server/gummymurderer/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     ALIBI_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 npc의 alibi를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     GAME_NOT_WON(HttpStatus.BAD_REQUEST, "GameResult가 SUCCESS가 아닙니다."),
-
+    INVALID_RESULT_MESSAGE(HttpStatus.BAD_REQUEST, "잘못된 ResultMessage 입니다."),
     ;
 
     private HttpStatus status;

--- a/src/main/java/com/server/gummymurderer/service/GameService.java
+++ b/src/main/java/com/server/gummymurderer/service/GameService.java
@@ -202,12 +202,11 @@ public class GameService {
 
         gameSet.endGameStatus();
 
-        if ("SUCCESS".equals(request.getResultMessage())) {
-            gameSet.gameSuccess();
-        } else if ("FAILURE".equals(request.getResultMessage())) {
+        if ("FAILURE".equals(request.getResultMessage())) {
             gameSet.gameFailed();
+        } else {
+            throw new AppException(ErrorCode.INVALID_RESULT_MESSAGE);
         }
-
         return new EndGameResponse(request.getResultMessage());
     }
 }


### PR DESCRIPTION
## 🌟(#171 ) GameEnd FAILURE만 넘어오게 수정


## ✍️내용
- GameResult FAILURE가 아닐 경우 예외 처리

## 📸스크린샷


## 🎈참고사항
