### PR TITLE
Feat/game/secretKeyValidation : secretKey 검증을 위한 전송 로직 추가

### DIFF
--- a/src/main/java/com/server/gummymurderer/controller/GameController.java
+++ b/src/main/java/com/server/gummymurderer/controller/GameController.java
@@ -19,6 +19,14 @@ public class GameController {
 
     private final GameService gameService;
 
+    @PostMapping("/key")
+    public Response<SecretKeyValidationResponse> validateSecretKey(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody SecretKeyValidationRequest request) {
+
+        Member loginMember = customUserDetails.getMember();
+        SecretKeyValidationResponse response = gameService.validationSecretKey(loginMember, request);
+        return Response.success(response);
+    }
+
     @PostMapping("/start")
     public ResponseEntity<Response<StartGameResponse>> startGame(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Member loginMember = customUserDetails.getMember();

--- a/src/main/java/com/server/gummymurderer/domain/dto/game/ErrorResponse.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/game/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.server.gummymurderer.domain.dto.game;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ErrorResponse {
+
+    private String detail;
+
+}

--- a/src/main/java/com/server/gummymurderer/domain/dto/game/SecretKeyValidationRequest.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/game/SecretKeyValidationRequest.java
@@ -1,0 +1,16 @@
+package com.server.gummymurderer.domain.dto.game;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SecretKeyValidationRequest {
+
+    private String secretKey;
+
+}

--- a/src/main/java/com/server/gummymurderer/domain/dto/game/SecretKeyValidationResponse.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/game/SecretKeyValidationResponse.java
@@ -1,0 +1,20 @@
+package com.server.gummymurderer.domain.dto.game;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SecretKeyValidationResponse {
+
+    private String message;
+    private boolean valid;
+    private String detail;
+
+}

--- a/src/main/java/com/server/gummymurderer/domain/dto/game/SuccessResponse.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/game/SuccessResponse.java
@@ -1,0 +1,13 @@
+package com.server.gummymurderer.domain.dto.game;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SuccessResponse {
+
+    private String message;
+    private Boolean valid;
+
+}

--- a/src/main/java/com/server/gummymurderer/exception/ErrorCode.java
+++ b/src/main/java/com/server/gummymurderer/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     GAME_NOT_WON(HttpStatus.BAD_REQUEST, "GameResult가 SUCCESS가 아닙니다."),
     INVALID_RESULT_MESSAGE(HttpStatus.BAD_REQUEST, "잘못된 ResultMessage 입니다."),
+    SECRET_KEY_UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Secret Key를 검증하는 동안 예기치 못한 오류가 발생했습니다."),
     ;
 
     private HttpStatus status;


### PR DESCRIPTION
## 🌟(#176 ) secretKey 검증을 위한 전송 로직 추가


## ✍️내용
- secretKeyValidation 추가
- Response가 null 일 경우 null 값인 필드는 JSON에 포함되지 않게 처리
- 상태 코드에 따른 Response 처리

## 📸스크린샷


## 🎈참고사항
