### PR TITLE
Refactor/user/signService : toEntity와 of를 사용하여 코드 정리

### DIFF
--- a/src/main/java/com/server/gummymurderer/domain/dto/member/SignRequest.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/member/SignRequest.java
@@ -1,5 +1,7 @@
 package com.server.gummymurderer.domain.dto.member;
 
+import com.server.gummymurderer.domain.entity.Authority;
+import com.server.gummymurderer.domain.entity.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -7,6 +9,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
 
 @Getter
 @Setter
@@ -31,5 +36,16 @@ public class SignRequest {
     @NotBlank(message = "email을 입력해주세요.")
     @Email(message = "email 형식에 맞게 작성해주세요.")
     private String email;
+
+    public Member toEntity(PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .account(getAccount())
+                .password(passwordEncoder.encode(getPassword()))
+                .name(getName())
+                .nickname(getNickname())
+                .email(getEmail())
+                .roles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()))
+                .build();
+    }
 
 }

--- a/src/main/java/com/server/gummymurderer/domain/dto/member/SignResponse.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/member/SignResponse.java
@@ -42,4 +42,28 @@ public class SignResponse {
         this.roles = member.getRoles();
         this.loginGameSetDTO = loginGameSetDTO;
     }
+
+    public static SignResponse of(Member member, List<LoginGameSetDTO> loginGameSetDTOList, String token) {
+        return SignResponse.builder()
+                .memberNo(member.getMemberNo())
+                .account(member.getAccount())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .roles(member.getRoles())
+                .token(token)
+                .loginGameSetDTO(loginGameSetDTOList)
+                .build();
+    }
+
+    public static SignResponse of(Member member) {
+        return SignResponse.builder()
+                .memberNo(member.getMemberNo())
+                .account(member.getAccount())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .roles(member.getRoles())
+                .build();
+    }
 }

--- a/src/main/java/com/server/gummymurderer/service/SignService.java
+++ b/src/main/java/com/server/gummymurderer/service/SignService.java
@@ -45,16 +45,9 @@ public class SignService {
                 .map(LoginGameSetDTO::new) // Assuming LoginGameSetDTO has a constructor that accepts a GameSet
                 .toList();
 
-        return SignResponse.builder()
-                .memberNo(member.getMemberNo())
-                .account(member.getAccount())
-                .name(member.getName())
-                .nickname(member.getNickname())
-                .email(member.getEmail())
-                .roles(member.getRoles())
-                .token(jwtProvider.createToken(member.getAccount(), member.getRoles()))
-                .loginGameSetDTO(loginGameSetDTOList)
-                .build();
+        String token = jwtProvider.createToken(member.getAccount(), member.getRoles());
+
+        return SignResponse.of(member, loginGameSetDTOList, token);
     }
 
     public SignResponse register(SignRequest request) {
@@ -74,25 +67,10 @@ public class SignService {
             throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
         }
 
-            Member member = Member.builder()
-                    .account(request.getAccount())
-                    .password(passwordEncoder.encode(request.getPassword()))
-                    .name(request.getName())
-                    .nickname(request.getNickname())
-                    .email(request.getEmail())
-                    .build();
+        Member member = request.toEntity(passwordEncoder);
 
-            member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        Member savedMember = memberRepository.save(member);
 
-            Member savedMember = memberRepository.save(member);
-
-        return SignResponse.builder()
-                .memberNo(savedMember.getMemberNo())
-                .account(savedMember.getAccount())
-                .name(savedMember.getName())
-                .nickname(savedMember.getNickname())
-                .email(savedMember.getEmail())
-                .roles(savedMember.getRoles())
-                .build();
+        return SignResponse.of(savedMember);
     }
 }


### PR DESCRIPTION
## 🌟(#182 ) SignService toEntity와 of를 사용하여 코드 정리


## ✍️내용
- SignRequest -> toEntity 메서드를 추가하여 Member entity를 생성하는 로직 분리
- SignResponse -> of 메서드를 추가하여 SignResponse를 생성하는 로직 분리

## 📸스크린샷


## 🎈참고사항
