### PR TITLE
Feat/loginSettings : Add user settings with default to login response

### DIFF
--- a/src/main/java/com/server/gummymurderer/domain/dto/gameSetting/GameSettingDTO.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/gameSetting/GameSettingDTO.java
@@ -1,0 +1,16 @@
+package com.server.gummymurderer.domain.dto.gameSetting;
+
+import com.server.gummymurderer.domain.enum_class.Language;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameSettingDTO {
+
+    private float backgroundSoundVolume;
+    private float effectSoundVolume;
+    private Language language;
+}

--- a/src/main/java/com/server/gummymurderer/domain/dto/member/SteamLoginResponse.java
+++ b/src/main/java/com/server/gummymurderer/domain/dto/member/SteamLoginResponse.java
@@ -1,6 +1,7 @@
 package com.server.gummymurderer.domain.dto.member;
 
 import com.server.gummymurderer.domain.dto.game.LoginGameSetDTO;
+import com.server.gummymurderer.domain.dto.gameSetting.GameSettingDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,5 +15,6 @@ public class SteamLoginResponse {
 
     private String token;
     private List<LoginGameSetDTO> loginGameSetDTO;
+    private GameSettingDTO gameSettingDTO;
 
 }

--- a/src/main/java/com/server/gummymurderer/repository/GameSettingRepository.java
+++ b/src/main/java/com/server/gummymurderer/repository/GameSettingRepository.java
@@ -1,11 +1,15 @@
 package com.server.gummymurderer.repository;
 
 import com.server.gummymurderer.domain.entity.GameSetting;
+import com.server.gummymurderer.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface GameSettingRepository extends JpaRepository<GameSetting, Long> {
 
+    Optional<GameSetting> findByMember(Member member);
 
 }

--- a/src/main/java/com/server/gummymurderer/service/SteamLoginService.java
+++ b/src/main/java/com/server/gummymurderer/service/SteamLoginService.java
@@ -5,11 +5,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.gummymurderer.configuration.jwt.JwtProvider;
 import com.server.gummymurderer.domain.dto.game.LoginGameSetDTO;
+import com.server.gummymurderer.domain.dto.gameSetting.GameSettingDTO;
 import com.server.gummymurderer.domain.dto.member.SteamLoginRequest;
 import com.server.gummymurderer.domain.dto.member.SteamLoginResponse;
 import com.server.gummymurderer.domain.entity.GameUserCustom;
 import com.server.gummymurderer.domain.entity.Member;
+import com.server.gummymurderer.domain.enum_class.Language;
 import com.server.gummymurderer.repository.GameSetRepository;
+import com.server.gummymurderer.repository.GameSettingRepository;
 import com.server.gummymurderer.repository.GameUserCustomRepository;
 import com.server.gummymurderer.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +46,7 @@ public class SteamLoginService {
     private final MemberRepository memberRepository; // 유저 정보 확인
     private final GameSetRepository gameSetRepository;
     private final GameUserCustomRepository gameUserCustomRepository;
+    private final GameSettingRepository gameSettingRepository;
 
     public SteamLoginResponse verifyAuthTicket(SteamLoginRequest request) throws JsonProcessingException {
 
@@ -85,8 +89,18 @@ public class SteamLoginService {
                 })
                 .toList();
 
+        GameSettingDTO settingDTO = gameSettingRepository.findByMember(member)
+                .map(setting -> new GameSettingDTO(
+                        setting.getBackgroundSoundVolume(),
+                        setting.getEffectSoundVolume(),
+                        setting.getLanguage()
+                ))
+                .orElseGet(() -> new GameSettingDTO(
+                        5.0f, 5.0f, Language.KO
+                ));
+
         log.info("🐻 loginGameSetDTO: {}", gameSetList);
 
-        return new SteamLoginResponse(token, gameSetList);
+        return new SteamLoginResponse(token, gameSetList, settingDTO);
     }
 }


### PR DESCRIPTION
## 🌟(#249 ) 로그인 시 사용자의 설정 값도 함께 return


## ✍️내용
- 로그인 시 사용자의 저장된 설정 값 return
- 사용자의 저장된 설정 값이 없을 경우 기본 값 전송

## 📸스크린샷


## 🎈참고사항
